### PR TITLE
[WiP] Enabling perf events monitoring in runc

### DIFF
--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -92,6 +92,21 @@ type HugetlbStats struct {
 	Failcnt uint64 `json:"failcnt"`
 }
 
+type PerfStats struct {
+	// Amount of time when event was enabled.
+	// If different then TimeRunning then multiplexing occured.
+	// You should scale Value accordingly.
+	// See man perf_event_open to learn more.
+	TimeEnabled uint64 `json:"time_enabled"`
+	// Amount of time when event was running. See TimeEnabled.
+	TimeRunning uint64 `json:"time_running"`
+	// Value of the event
+	Value uint64 `json:"value"`
+	// Event ID. The field is redundant in Stats.PerfEventStats,
+	// but allows to use the struct to pass event value around.
+	ID uint64 `json:"id"`
+}
+
 type Stats struct {
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
@@ -99,10 +114,13 @@ type Stats struct {
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
 	// the map is in the format "size of hugepage: stats of the hugepage"
 	HugetlbStats map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
+	// the map is in the format "event id: event stats"
+	PerfStats map[uint64]PerfStats `json:"perf_event_stats,omitempty"`
 }
 
 func NewStats() *Stats {
 	memoryStats := MemoryStats{Stats: make(map[string]uint64)}
 	hugetlbStats := make(map[string]HugetlbStats)
-	return &Stats{MemoryStats: memoryStats, HugetlbStats: hugetlbStats}
+	perfStats := make(map[uint64]PerfStats)
+	return &Stats{MemoryStats: memoryStats, HugetlbStats: hugetlbStats, PerfStats: perfStats}
 }

--- a/libcontainer/cgroups/stats.go
+++ b/libcontainer/cgroups/stats.go
@@ -98,10 +98,13 @@ type PerfStats struct {
 	// You should scale Value accordingly.
 	// See man perf_event_open to learn more.
 	TimeEnabled uint64 `json:"time_enabled"`
+
 	// Amount of time when event was running. See TimeEnabled.
 	TimeRunning uint64 `json:"time_running"`
+
 	// Value of the event
 	Value uint64 `json:"value"`
+
 	// Event ID. The field is redundant in Stats.PerfEventStats,
 	// but allows to use the struct to pass event value around.
 	ID uint64 `json:"id"`
@@ -114,7 +117,9 @@ type Stats struct {
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
 	// the map is in the format "size of hugepage: stats of the hugepage"
 	HugetlbStats map[string]HugetlbStats `json:"hugetlb_stats,omitempty"`
-	// the map is in the format "event id: event stats"
+	// the map is in the format "event id: event stats".
+	// Event id is sum of configuration values as described at man perf-stat
+	// for case: pmu/config=M,config1=N,config2=K/
 	PerfStats map[uint64]PerfStats `json:"perf_event_stats,omitempty"`
 }
 

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -38,6 +38,9 @@ type Cgroup struct {
 	// derived from org.systemd.property.xxx annotations.
 	// Ignored unless systemd is used for managing cgroups.
 	SystemdProps []systemdDbus.Property `json:"-"`
+
+	// List of perf subsytem events IDs that will be measured.
+	PerfEvents []uint64
 }
 
 type Resources struct {

--- a/libcontainer/configs/cgroup_linux.go
+++ b/libcontainer/configs/cgroup_linux.go
@@ -1,6 +1,8 @@
 package configs
 
 import (
+	"time"
+
 	systemdDbus "github.com/coreos/go-systemd/dbus"
 )
 
@@ -39,8 +41,33 @@ type Cgroup struct {
 	// Ignored unless systemd is used for managing cgroups.
 	SystemdProps []systemdDbus.Property `json:"-"`
 
-	// List of perf subsytem events IDs that will be measured.
-	PerfEvents []uint64
+	// Contains configuration of perf events to be measured.
+	Perf *Perf
+}
+
+type Perf struct {
+	// List of perf events to be measured. Events in this list
+	// will not be grouped. See group_fd argument documentation
+	// at man perf_event_open.
+	Events []PerfEvent
+
+	// List of groups of events to be measured. See group_fd
+	// argument documentation at man perf_event_open.
+	GroupedEvents [][]PerfEvent
+
+	// Interval between each measurement.
+	Interval time.Duration
+}
+
+type PerfEvent struct {
+	// Type of the event. See perf_event_attr documentation
+	// at man perf_event_open.
+	Type uint32
+
+	// Symbolically formed event like:
+	// pmu/config=PerfEvent.Config[0],config1=PerfEvent.Config[1],config2=PerfEvent.Config[2]
+	// as described in man perf-stat.
+	Config []uint64
 }
 
 type Resources struct {


### PR DESCRIPTION
This is sketch of configuration changes necessary to start monitoring perf events for a container that `runc` starts. Any changes to `configs.Cgroup` and its properties would have to be reflected in [OCI runtime spec](https://github.com/opencontainers/runtime-spec/blob/v1.0.1/schema/config-linux.json).